### PR TITLE
feat(android): expose app category and optional icon in queryAllPackages

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ npx cap sync
 * [`queryAndAggregateUsageStats(...)`](#queryandaggregateusagestats)
 * [`isUsageStatsPermissionGranted()`](#isusagestatspermissiongranted)
 * [`openUsageStatsSettings()`](#openusagestatssettings)
-* [`queryAllPackages()`](#queryallpackages)
+* [`queryAllPackages(...)`](#queryallpackages)
 * [`getPluginVersion()`](#getpluginversion)
 * [Interfaces](#interfaces)
 * [Type Aliases](#type-aliases)
@@ -137,14 +137,18 @@ This will always open the settings screen, even if the permission is already gra
 --------------------
 
 
-### queryAllPackages()
+### queryAllPackages(...)
 
 ```typescript
-queryAllPackages() => Promise<{ packages: PackageInfo[]; }>
+queryAllPackages(options?: QueryAllPackagesOptions | undefined) => Promise<{ packages: PackageInfo[]; }>
 ```
 
 Queries all installed packages on the device.
 Requires the QUERY_ALL_PACKAGES permission.
+
+| Param         | Type                                                                        | Description               |
+| ------------- | --------------------------------------------------------------------------- | ------------------------- |
+| **`options`** | <code><a href="#queryallpackagesoptions">QueryAllPackagesOptions</a></code> | - Optional query settings |
 
 **Returns:** <code>Promise&lt;{ packages: PackageInfo[]; }&gt;</code>
 
@@ -211,14 +215,25 @@ Result of a usage stats permission check.
 
 Represents basic information about an installed package.
 
-| Prop                   | Type                | Description                                    |
-| ---------------------- | ------------------- | ---------------------------------------------- |
-| **`packageName`**      | <code>string</code> | Package name                                   |
-| **`appName`**          | <code>string</code> | App display name                               |
-| **`versionName`**      | <code>string</code> | Version name string                            |
-| **`versionCode`**      | <code>number</code> | Version code number                            |
-| **`firstInstallTime`** | <code>number</code> | First install time in milliseconds since epoch |
-| **`lastUpdateTime`**   | <code>number</code> | Last update time in milliseconds since epoch   |
+| Prop                   | Type                | Description                                                                                                                                                                                                                                                         | Since  |
+| ---------------------- | ------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ------ |
+| **`packageName`**      | <code>string</code> | Package name                                                                                                                                                                                                                                                        |        |
+| **`appName`**          | <code>string</code> | App display name                                                                                                                                                                                                                                                    |        |
+| **`versionName`**      | <code>string</code> | Version name string                                                                                                                                                                                                                                                 |        |
+| **`versionCode`**      | <code>number</code> | Version code number                                                                                                                                                                                                                                                 |        |
+| **`firstInstallTime`** | <code>number</code> | First install time in milliseconds since epoch                                                                                                                                                                                                                      |        |
+| **`lastUpdateTime`**   | <code>number</code> | Last update time in milliseconds since epoch                                                                                                                                                                                                                        |        |
+| **`category`**         | <code>number</code> | Application category from `ApplicationInfo.category`. Only available on Android 8.0 (API level 26) and above. Common values: - `0` — undefined - `1` — game - `2` — audio - `3` — video - `4` — image - `5` — social - `6` — news - `7` — maps - `8` — productivity | 8.0.33 |
+| **`icon`**             | <code>string</code> | App icon as a base64 data URL (`data:image/png;base64,...`). Only present when `queryAllPackages({ includeIcon: true })` is used.                                                                                                                                   | 8.0.33 |
+
+
+#### QueryAllPackagesOptions
+
+Options for querying installed packages.
+
+| Prop              | Type                 | Description                                                                                                                                  | Default            |
+| ----------------- | -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ------------------ |
+| **`includeIcon`** | <code>boolean</code> | When true, includes each app's launcher icon as a base64 data URL. Defaults to false because icons significantly increase the response size. | <code>false</code> |
 
 
 ### Type Aliases

--- a/android/src/main/java/ee/forgr/capacitor_android_usagestatsmanager/CapacitorUsageStatsManagerPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_android_usagestatsmanager/CapacitorUsageStatsManagerPlugin.java
@@ -11,12 +11,18 @@ import android.content.pm.PackageManager;
 import android.os.Build;
 import android.provider.Settings;
 import android.util.Log;
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
+import android.util.Base64;
 import androidx.annotation.NonNull;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
 import com.getcapacitor.PluginCall;
 import com.getcapacitor.PluginMethod;
 import com.getcapacitor.annotation.CapacitorPlugin;
+import java.io.ByteArrayOutputStream;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.util.List;
@@ -97,9 +103,9 @@ public class CapacitorUsageStatsManagerPlugin extends Plugin {
             call.reject("Error during openUsageStatsSettings: " + sw);
         }
     }
-
     @PluginMethod
     public void queryAllPackages(final PluginCall call) {
+        final boolean includeIcon = Boolean.TRUE.equals(call.getBoolean("includeIcon", false));
         PackageManager pm = getContext().getPackageManager();
         List<PackageInfo> packages = pm.getInstalledPackages(0);
         JSObject result = new JSObject();
@@ -108,11 +114,26 @@ public class CapacitorUsageStatsManagerPlugin extends Plugin {
         for (PackageInfo packageInfo : packages) {
             JSObject packageJS = new JSObject();
             packageJS.put("packageName", packageInfo.packageName);
+            ApplicationInfo appInfo = null;
             try {
-                ApplicationInfo appInfo = pm.getApplicationInfo(packageInfo.packageName, 0);
+                appInfo = pm.getApplicationInfo(packageInfo.packageName, 0);
                 packageJS.put("appName", pm.getApplicationLabel(appInfo).toString());
             } catch (PackageManager.NameNotFoundException e) {
                 packageJS.put("appName", packageInfo.packageName);
+            }
+            if (appInfo != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                packageJS.put("category", appInfo.category);
+            }
+            if (includeIcon && appInfo != null) {
+                try {
+                    Drawable icon = pm.getApplicationIcon(appInfo);
+                    String iconDataUrl = drawableToBase64DataUrl(icon);
+                    if (iconDataUrl != null) {
+                        packageJS.put("icon", iconDataUrl);
+                    }
+                } catch (Exception e) {
+                    Log.w("CapacitorUsageStatsManager", "Failed to load icon for " + packageInfo.packageName, e);
+                }
             }
             packageJS.put("versionName", packageInfo.versionName);
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
@@ -128,6 +149,34 @@ public class CapacitorUsageStatsManagerPlugin extends Plugin {
         }
         result.put("packages", packagesJA);
         call.resolve(result);
+    }
+
+    private static String drawableToBase64DataUrl(Drawable drawable) {
+        if (drawable == null) {
+            return null;
+        }
+
+        Bitmap bitmap;
+        if (drawable instanceof BitmapDrawable) {
+            bitmap = ((BitmapDrawable) drawable).getBitmap();
+            if (bitmap == null) {
+                return null;
+            }
+        } else {
+            int width = drawable.getIntrinsicWidth() > 0 ? drawable.getIntrinsicWidth() : 1;
+            int height = drawable.getIntrinsicHeight() > 0 ? drawable.getIntrinsicHeight() : 1;
+            bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+            Canvas canvas = new Canvas(bitmap);
+            drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+            drawable.draw(canvas);
+        }
+
+        ByteArrayOutputStream stream = new ByteArrayOutputStream();
+        if (!bitmap.compress(Bitmap.CompressFormat.PNG, 100, stream)) {
+            return null;
+        }
+
+        return "data:image/png;base64," + Base64.encodeToString(stream.toByteArray(), Base64.NO_WRAP);
     }
 
     @NonNull

--- a/android/src/main/java/ee/forgr/capacitor_android_usagestatsmanager/CapacitorUsageStatsManagerPlugin.java
+++ b/android/src/main/java/ee/forgr/capacitor_android_usagestatsmanager/CapacitorUsageStatsManagerPlugin.java
@@ -8,14 +8,14 @@ import android.content.Intent;
 import android.content.pm.ApplicationInfo;
 import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
-import android.os.Build;
-import android.provider.Settings;
-import android.util.Log;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
+import android.os.Build;
+import android.provider.Settings;
 import android.util.Base64;
+import android.util.Log;
 import androidx.annotation.NonNull;
 import com.getcapacitor.JSObject;
 import com.getcapacitor.Plugin;
@@ -103,6 +103,7 @@ public class CapacitorUsageStatsManagerPlugin extends Plugin {
             call.reject("Error during openUsageStatsSettings: " + sw);
         }
     }
+
     @PluginMethod
     public void queryAllPackages(final PluginCall call) {
         final boolean includeIcon = Boolean.TRUE.equals(call.getBoolean("includeIcon", false));

--- a/src/definitions.ts
+++ b/src/definitions.ts
@@ -141,18 +141,19 @@ export interface CapacitorUsageStatsManagerPlugin {
    * Queries all installed packages on the device.
    * Requires the QUERY_ALL_PACKAGES permission.
    *
+   * @param options - Optional query settings
    * @returns Promise that resolves with an array of package information
    * @throws Error if the permission is not granted or query fails
    * @since 1.2.0
    * @example
    * ```typescript
-   * const { packages } = await UsageStatsManager.queryAllPackages();
+   * const { packages } = await UsageStatsManager.queryAllPackages({ includeIcon: true });
    * packages.forEach(pkg => {
-   *   console.log(`${pkg.appName} (${pkg.packageName}): v${pkg.versionName}`);
+   *   console.log(`${pkg.appName} (${pkg.packageName}): category=${pkg.category}`);
    * });
    * ```
    */
-  queryAllPackages(): Promise<{ packages: PackageInfo[] }>;
+  queryAllPackages(options?: QueryAllPackagesOptions): Promise<{ packages: PackageInfo[] }>;
 
   /**
    * Get the native Capacitor plugin version.
@@ -200,6 +201,21 @@ export interface UsageEvent {
 }
 
 /**
+ * Options for querying installed packages.
+ *
+ * @since 8.0.33
+ */
+export interface QueryAllPackagesOptions {
+  /**
+   * When true, includes each app's launcher icon as a base64 data URL.
+   * Defaults to false because icons significantly increase the response size.
+   *
+   * @default false
+   */
+  includeIcon?: boolean;
+}
+
+/**
  * Represents basic information about an installed package.
  *
  * @since 1.0.0
@@ -217,4 +233,29 @@ export interface PackageInfo {
   firstInstallTime: number;
   /** Last update time in milliseconds since epoch */
   lastUpdateTime: number;
+  /**
+   * Application category from `ApplicationInfo.category`.
+   * Only available on Android 8.0 (API level 26) and above.
+   *
+   * Common values:
+   * - `0` — undefined
+   * - `1` — game
+   * - `2` — audio
+   * - `3` — video
+   * - `4` — image
+   * - `5` — social
+   * - `6` — news
+   * - `7` — maps
+   * - `8` — productivity
+   *
+   * @since 8.0.33
+   */
+  category?: number;
+  /**
+   * App icon as a base64 data URL (`data:image/png;base64,...`).
+   * Only present when `queryAllPackages({ includeIcon: true })` is used.
+   *
+   * @since 8.0.33
+   */
+  icon?: string;
 }

--- a/src/web.ts
+++ b/src/web.ts
@@ -12,7 +12,7 @@ export class CapacitorUsageStatsManagerWeb extends WebPlugin implements Capacito
   queryAndAggregateUsageStats(_options: any): Promise<Record<string, any>> {
     throw new Error('Method not implemented.');
   }
-  queryAllPackages(): Promise<{ packages: PackageInfo[] }> {
+  queryAllPackages(_options?: { includeIcon?: boolean }): Promise<{ packages: PackageInfo[] }> {
     throw new Error('Method not implemented.');
   }
 


### PR DESCRIPTION
## Summary
- Adds `category` to `PackageInfo`, mapped from `ApplicationInfo.category` on Android 8.0+ (API 26)
- Adds optional `icon` field (base64 PNG data URL) when calling `queryAllPackages({ includeIcon: true })`
- Introduces `QueryAllPackagesOptions` so icons stay opt-in and avoid large payloads by default

## Usage
```typescript
const { packages } = await CapacitorUsageStatsManager.queryAllPackages({ includeIcon: true });

packages.forEach(pkg => {
  console.log(pkg.appName, pkg.category, pkg.icon?.slice(0, 30));
});
```

`category` values follow Android constants (`0` undefined, `1` game, `2` audio, `3` video, `4` image, `5` social, `6` news, `7` maps, `8` productivity).

## Test plan
- [x] `bun run verify:android` passes locally
- [x] `bun run verify:web` passes locally
- [ ] CI test workflow passes
- [ ] Manual check on Android device: `queryAllPackages()` returns `category`
- [ ] Manual check on Android device: `queryAllPackages({ includeIcon: true })` returns valid `icon` data URLs


Made with [Cursor](https://cursor.com)